### PR TITLE
Refactoring of existing logic, for testability and extensibility

### DIFF
--- a/common/contract.ts
+++ b/common/contract.ts
@@ -79,11 +79,11 @@ export class Changes {
 	/** Records that need to be deleted */
 	Delete = new Array<Endpoint>();
 
-	length() {
+	get length() {
 		return this.Create.length + this.Update.length + this.Delete.length;
 	}
 
-	summary() {
+	get summary() {
 		return [
 			this.Create.length, 'creates,',
 			this.Update.length, 'updates,',

--- a/common/contract.ts
+++ b/common/contract.ts
@@ -55,8 +55,6 @@ export interface Endpoint {
 
 	/** ProviderSpecific stores provider specific config */
 	ProviderSpecific?: Array<ProviderSpecificProperty>;
-
-	SplitOutTarget(predicate: (t: string) => boolean): [Endpoint, Endpoint];
 }
 
 /** ProviderSpecificProperty holds the name and value of a configuration which is specific to individual DNS providers */

--- a/common/endpoints.ts
+++ b/common/endpoints.ts
@@ -1,18 +1,18 @@
 import { Endpoint } from "./contract.ts";
 
 /// Basic function for non-special cases
-export function SplitOutTarget(this: Endpoint, predicate: (t: string) => boolean): [Endpoint, Endpoint] {
+export function SplitOutTarget(self: Endpoint, predicate: (t: string) => boolean): [Endpoint, Endpoint] {
   return [{
-    ...this,
-    Targets: this.Targets.filter(predicate),
+    ...self,
+    Targets: self.Targets.filter(predicate),
   }, {
-    ...this,
-    Targets: this.Targets.filter(x => !predicate(x)),
+    ...self,
+    Targets: self.Targets.filter(x => !predicate(x)),
   }];
 }
 
 export function SplitByIPVersion(all: Endpoint): Endpoint[] {
-  const [aaaa, a] = all.SplitOutTarget(t => t.includes(':'));
+  const [aaaa, a] = SplitOutTarget(all, t => t.includes(':'));
   const endpoints = new Array<Endpoint>();
   if (aaaa.Targets.length > 0) {
     aaaa.RecordType = 'AAAA';

--- a/common/endpoints_test.ts
+++ b/common/endpoints_test.ts
@@ -1,7 +1,6 @@
 import { assertEquals } from "https://deno.land/std@0.105.0/testing/asserts.ts";
 
-import type { Endpoint } from "./contract.ts";
-import { SplitByIPVersion, SplitOutTarget } from "./endpoints.ts";
+import { SplitByIPVersion } from "./endpoints.ts";
 
 Deno.test('Endpoint SplitByIPVersion: Dualstack targets', () => {
   verifySplitByIPVersion({
@@ -54,7 +53,6 @@ function verifySplitByIPVersion(opts: {
     DNSName: 'example.com',
     RecordType: 'A',
     Targets: opts.inputTargets,
-    SplitOutTarget,
   });
 
   // Check number of resulting endpoints

--- a/controller/integration_test.ts
+++ b/controller/integration_test.ts
@@ -1,0 +1,113 @@
+import { assertEquals } from "https://deno.land/std@0.105.0/testing/asserts.ts";
+import { DnsProvider, DnsProviderContext, DnsRegistry, DnsRegistryContext, Endpoint } from "../common/contract.ts";
+
+import { DnsRecord, DnsRecordData, DomainRecord } from "../providers/vultr/api.ts";
+import { VultrProvider } from "../providers/vultr/mod.ts";
+import { TxtRegistry } from "../registries/txt.ts";
+import { Planner } from "./planner.ts";
+
+Deno.test("[E2E] Update A record: TXT registry, Vultr provider", async () => {
+
+  const registry = new TxtRegistry({
+    txt_owner_id: 'dnssynctest',
+    type: 'txt',
+  });
+
+  const provider = new VultrProvider({
+    type: 'vultr',
+    domain_filter: ['example.com'],
+  }, {
+    async *listAllZones(): AsyncGenerator<DomainRecord> {
+      yield {
+        domain: 'example.com',
+        date_created: 'mock',
+      };
+    },
+    async *listAllRecords(): AsyncGenerator<DnsRecord> {
+      yield {
+        id: 'www-A',
+        name: 'www',
+        type: 'A',
+        data: '1.1.1.1',
+        priority: 0,
+        ttl: 60,
+      };
+      yield {
+        id: 'www-registry',
+        name: 'www',
+        type: 'TXT',
+        data: '"heritage=external-dns,external-dns/owner=dnssynctest,record-type/A=managed"',
+        priority: 0,
+        ttl: 60,
+      };
+    },
+    createRecord(zone: string,
+      record: DnsRecordData,
+    ): Promise<DnsRecord> {
+      assertEquals(zone, 'example.com');
+      assertEquals(record.name, 'www');
+      assertEquals(record.data, '2.2.2.2');
+      return Promise.resolve({
+        priority: 0,
+        ttl: 60,
+        ...record,
+        id: 'new-www-A',
+      })
+    },
+    updateRecord(zone: string,
+      recordId: string,
+      changes: Partial<Omit<DnsRecordData, "type">>,
+    ): Promise<void> {
+      return Promise.reject(new Error('TODO'));
+    },
+    deleteRecord(zone: string,
+      recordId: string,
+    ): Promise<void> {
+      assertEquals(zone, 'example.com');
+      assertEquals(recordId, 'www-A');
+      return Promise.resolve();
+    },
+  });
+
+  const sourceRecords: Array<Endpoint> = [{
+    DNSName: "www.example.com",
+    RecordType: "A",
+    Targets: ["2.2.2.2"],
+  }];
+
+  const rawChanges = await performMain(provider, registry, sourceRecords);
+
+  assertEquals(rawChanges.Create.length, 0);
+  assertEquals(rawChanges.Update.length, 1);
+  assertEquals(rawChanges.Delete.length, 0);
+});
+
+/**
+ * This is a mirror of mod.ts/output.ts except without any logging/prompting.
+ * Also, DnsSource isn't used because it doesn't really interact with planning.
+ */
+async function performMain<
+  Tprovider extends DnsProviderContext,
+  Tregistry extends DnsRegistryContext,
+>(
+  provider: DnsProvider<Tprovider>,
+  registry: DnsRegistry<Tregistry>,
+  sourceRecords: Array<Endpoint>,
+) {
+  // Create contexts
+  const providerCtx = await provider.NewContext();
+  const registryCtx = registry.NewContext(providerCtx.Zones);
+  // Load existing records
+  const rawExisting = await providerCtx.Records();
+  const existingRecords = await registryCtx.RecognizeLabels(rawExisting);
+  // Plan changes using source records
+  const planner = new Planner(providerCtx.Zones);
+  const changes = planner.PlanChanges(sourceRecords, existingRecords);
+  // Push desired changes back to the provider
+  const rawChanges = await registryCtx.CommitLabels(changes);
+  if (rawChanges.length > 0) {
+    // It's ok to always call this, but the real program only calls when needed
+    await providerCtx.ApplyChanges(rawChanges);
+  }
+  return rawChanges;
+}

--- a/controller/output.ts
+++ b/controller/output.ts
@@ -1,0 +1,105 @@
+import type {
+  Endpoint, Changes,
+  DnsProviderContext,
+  DnsRegistryContext,
+} from "../common/mod.ts";
+import { Planner } from "./planner.ts";
+
+export const p3 = '   ';
+export const p2 = '-->';
+export const p1 = '==>';
+export const p0 = '!!!';
+
+export function printTick(tickVia: string | undefined) {
+  console.log();
+  const tickReason = tickVia
+    ? `via ${tickVia}`
+    : 'via schedule';
+  console.log('---', new Date().toISOString(), tickReason);
+}
+
+export async function loadSourceEndpoints(sources: Array<{
+  Endpoints: () => Promise<Array<Endpoint>>;
+  config: { type: string },
+}>) {
+  console.log(p2, 'Loading desired records from', sources.length, 'sources...');
+  const sourceRecords = await Promise.all(sources.map(async source => {
+    const endpoints = await source.Endpoints();
+    console.log(p3, 'Discovered', endpoints.length, 'desired records from', source.config.type);
+    return endpoints;
+  })).then(x => x.flat());
+  console.log(p2, 'Discovered', sourceRecords.length, 'desired records overall');
+  return sourceRecords;
+}
+
+export async function discoverProviderChanges<T>(
+  registryCtx: DnsRegistryContext,
+  providerId: string,
+  providerCtx: DnsProviderContext,
+  sourceRecords: Endpoint[],
+) {
+  console.log(p3, 'Loading existing records from', providerId, '...');
+  const rawExisting = await providerCtx.Records();
+  console.log(p3, 'Recognizing ownership labels on', rawExisting.length, 'records...');
+  const existingRecords = await registryCtx.RecognizeLabels(rawExisting);
+  console.log(p2, 'Found', existingRecords.length, 'existing records from', providerId);
+
+  const planner = new Planner(providerCtx.Zones);
+  const changes = planner.PlanChanges(sourceRecords, existingRecords);
+  console.log(p3, 'Planner changes:', ...changes.summary);
+
+  console.log(p3, 'Encoding changed ownership labels...');
+  return await registryCtx.CommitLabels(changes);
+}
+
+export function printChanges(changes: Changes) {
+  for (const rec of changes.Create) {
+    if (rec.RecordType === 'TXT') { // long records
+      console.log(p2, '- Create:', rec.RecordType, rec.DNSName);
+      for (const targetVal of rec.Targets) {
+        console.log(p3, '    new:', targetVal);
+      }
+    } else {
+      console.log(p2, '- Create:', rec.RecordType, rec.DNSName, rec.Targets);
+    }
+  }
+
+  for (const [recOld, recNew] of changes.Update) {
+    if (recOld.RecordType === 'TXT') { // long records
+      console.log(p2, '- Update:', recOld.RecordType, recOld.DNSName);
+      for (const targetVal of recOld.Targets) {
+        console.log(p3, '    old:', targetVal);
+      }
+      for (const targetVal of recNew.Targets) {
+        console.log(p3, '    new:', targetVal);
+      }
+    } else {
+      console.log(p2, '- Update:', recOld.RecordType, recOld.DNSName, recOld.Targets, '->', recNew.Targets);
+    }
+  }
+
+  for (const rec of changes.Delete) {
+    if (rec.RecordType === 'TXT') { // long records
+      console.log(p2, '- Delete:', rec.RecordType, rec.DNSName);
+      for (const targetVal of rec.Targets) {
+        console.log(p3, '    old:', targetVal);
+      }
+    } else {
+      console.log(p2, '- Delete:', rec.RecordType, rec.DNSName, rec.Targets);
+    }
+  }
+}
+
+export function confirmBeforeApplyingChanges() {
+  if (Deno.args.includes('--dry-run')) {
+    console.log(p1, "Doing no changes due to --dry-run");
+    return false;
+
+  } else if (!Deno.args.includes('--yes')) {
+    const result = prompt(`${p3} Proceed with editing provider records?`, 'no');
+    if (result !== 'yes') throw new Error(
+      `User declined to perform provider edits`);
+  }
+
+  return true;
+}

--- a/controller/planner_test.ts
+++ b/controller/planner_test.ts
@@ -1,0 +1,114 @@
+import { assertEquals, assertThrows } from "https://deno.land/std@0.105.0/testing/asserts.ts";
+
+import { Planner } from "./planner.ts";
+
+Deno.test("first-time plan (happy path)", () => {
+  const planner = new Planner([{
+    DNSName: "example.com",
+    ZoneID: "ex",
+  }]);
+
+  const changes = planner.PlanChanges([{
+    DNSName: "app.example.com",
+    RecordType: "A",
+    Targets: ["1.1.1.1"],
+  }], []);
+
+  assertEquals(changes.Create.length, 1);
+  assertEquals(changes.Update.length, 0);
+  assertEquals(changes.Delete.length, 0);
+
+  const [creation] = changes.Create;
+  assertEquals(creation.DNSName, "app.example.com");
+  assertEquals(creation.RecordType, "A");
+  assertEquals(creation.Targets, ["1.1.1.1"]);
+});
+
+Deno.test("first-time plan (unknown domain)", () => {
+  const planner = new Planner([{
+    DNSName: "example.com",
+    ZoneID: "ex",
+  }]);
+
+  const changes = planner.PlanChanges([{
+    DNSName: "app.another.com",
+    RecordType: "A",
+    Targets: ["1.1.1.1"],
+  }], []);
+
+  assertEquals(changes.Create.length, 0);
+  assertEquals(changes.Update.length, 0);
+  assertEquals(changes.Delete.length, 0);
+});
+
+Deno.test("no-change plan", () => {
+  const planner = new Planner([{
+    DNSName: "example.com",
+    ZoneID: "ex",
+  }]);
+
+  const changes = planner.PlanChanges([{
+    DNSName: "app.example.com",
+    RecordType: "A",
+    Targets: ["1.1.1.1"],
+  }], [{
+    DNSName: "app.example.com",
+    RecordType: "A",
+    Targets: ["1.1.1.1"],
+    Labels: {'is-ours': 'yes'},
+  }]);
+
+  assertEquals(changes.Create.length, 0);
+  assertEquals(changes.Update.length, 0);
+  assertEquals(changes.Delete.length, 0);
+});
+
+Deno.test("plan with record updates", () => {
+  const planner = new Planner([{
+    DNSName: "example.com",
+    ZoneID: "ex",
+  }]);
+
+  const changes = planner.PlanChanges([{
+    DNSName: "app.example.com",
+    RecordType: "A",
+    Targets: ["2.2.2.2", "3.3.3.3"],
+  }], [{
+    DNSName: "app.example.com",
+    RecordType: "A",
+    Targets: ["1.1.1.1"],
+    Labels: {'is-ours': 'yes'},
+  }]);
+
+  assertEquals(changes.Create.length, 0);
+  assertEquals(changes.Update.length, 1);
+  assertEquals(changes.Delete.length, 0);
+
+  const [update] = changes.Update;
+  assertEquals(update[0].DNSName, "app.example.com");
+  assertEquals(update[1].DNSName, "app.example.com");
+  assertEquals(update[0].RecordType, "A");
+  assertEquals(update[1].RecordType, "A");
+  assertEquals(update[0].Targets, ["1.1.1.1"]);
+  assertEquals(update[1].Targets, ["2.2.2.2", "3.3.3.3"]);
+});
+
+Deno.test("conflicting records", () => {
+  const planner = new Planner([{
+    DNSName: "example.com",
+    ZoneID: "ex",
+  }]);
+
+  assertThrows(() => {
+    const changes = planner.PlanChanges([{
+      DNSName: "app.example.com",
+      RecordType: "A",
+      Targets: ["1.1.1.1"],
+    }], [{
+      DNSName: "app.example.com",
+      RecordType: "A",
+      Targets: ["1.1.1.1"],
+      Labels: {'is-ours': ''},
+    }]);
+  }, Error, 'clash with unmanaged records');
+});

--- a/providers/google/mod.ts
+++ b/providers/google/mod.ts
@@ -2,7 +2,6 @@ import {
   GoogleProviderConfig,
   DnsProvider, DnsProviderContext,
   Zone, Endpoint, Changes,
-  SplitOutTarget,
 } from "../../common/mod.ts";
 import { GoogleCloudDnsApi,
   Schema$Change,
@@ -64,7 +63,6 @@ export class GoogleProviderContext implements DnsProviderContext {
           Targets: decodeTargets(record.type!, record.rrdatas!),
           RecordTTL: record.ttl ?? undefined,
           Priority: undefined,
-          SplitOutTarget,
         });
 
       }

--- a/providers/opaquely-identified.ts
+++ b/providers/opaquely-identified.ts
@@ -1,0 +1,112 @@
+import { Changes, DnsProviderContext, Endpoint, Zone } from "../common/contract.ts";
+
+export type RecordEndpoint = Endpoint & {
+  Targets: [string]; // enforce exactly one value
+  RecordID: string;
+};
+
+/**
+ * Base class implementing common logic for providers which
+ * assign every record value/target its own opaque "record ID".
+ * Many smaller API-first cloud providers do this when they add a DNS offering.
+ * Examples: Cloudflare, Vultr
+ * Note that this API design generally lacks atomic zone updates,
+ * as deleting a record and creating its replacement becomes two API calls.
+ *
+ * Larger clouds (such as Google and AWS) tend to focus instead on atomic "record set" upserts,
+ * so this tracking logic is not useful for using their APIs.
+ */
+export abstract class OpaquelyIdentifiedProviderContext implements DnsProviderContext {
+  constructor(
+    public Zones: Array<Zone>,
+  ) {}
+
+  abstract enumerateRecords(zone: Zone): AsyncGenerator<RecordEndpoint>;
+  abstract createRecord(zone: Zone, endpoint: Endpoint, value: string): Promise<void>;
+  abstract deleteRecord(zone: Zone, recordId: string): Promise<void>;
+
+  private recordIds = new Map<string, string>();
+  private recordKey(name: string, type: string, priority: number | null | undefined, value: string) {
+    return JSON.stringify([name, type, priority ?? null, value]);
+  }
+
+  findZoneForName(dnsName: string): Zone | undefined {
+    const matches = this.Zones.filter(x => x.DNSName == dnsName || dnsName.endsWith('.'+x.DNSName));
+    return matches.sort((a,b) => b.DNSName.length - a.DNSName.length)[0];
+  }
+
+  async Records(): Promise<Endpoint[]> {
+    const endpoints = new Array<Endpoint>(); // every recordset we find
+    for (const zone of this.Zones) {
+
+      const endpMap = new Map<string, Endpoint>(); // collapse targets with same name/type/priority
+
+      for await (const {RecordID, ...record} of this.enumerateRecords(zone)) {
+        if (record.Targets.length !== 1) throw new Error(
+          `BUG: Expected provider Endpoint to have exactly 1 target, not ${record.Targets.length}`);
+
+        const mapKey = [record.DNSName, record.RecordType, record.Priority].join(':');
+
+        const recordKey = this.recordKey(record.DNSName, record.RecordType, record.Priority, record.Targets[0]);
+        if (this.recordIds.has(recordKey)) throw new Error(`Record key ${recordKey} overlapped`);
+        this.recordIds.set(recordKey, RecordID);
+
+        const existingEndp = endpMap.get(mapKey);
+        if (existingEndp) {
+          existingEndp.Targets.push(record.Targets[0]);
+        } else {
+          // how is this type-sound? once it's in endpoints, Targets can have more values added
+          record.Targets = [record.Targets[0]];
+          endpoints.push(record);
+          endpMap.set(mapKey, record);
+        }
+
+      }
+    }
+    return endpoints;
+  }
+
+  async ApplyChanges(changes: Changes): Promise<void> {
+
+    for (const deleted of changes.Delete as Endpoint[]) {
+      const zone = this.findZoneForName(deleted.DNSName);
+      if (!zone) throw new Error(`Zone not found for ${deleted.DNSName}`);
+
+      for (const target of deleted.Targets) {
+        const recordKey = this.recordKey(deleted.DNSName, deleted.RecordType, deleted.Priority, target);
+        const recordId = this.recordIds.get(recordKey);
+        if (!recordId) throw new Error(`BUG: No record ID found for ${recordKey}`);
+
+        await this.deleteRecord(zone, recordId);
+      }
+    }
+
+    for (const [before, after] of changes.Update as Array<[Endpoint, Endpoint]>) {
+      const zone = this.findZoneForName(before.DNSName);
+      if (!zone) throw new Error(`zone not found for ${before.DNSName}`);
+
+      // TODO: be more efficient with updating-in-place
+      for (const target of before.Targets) {
+        const recordKey = this.recordKey(before.DNSName, before.RecordType, before.Priority, target);
+        const recordId = this.recordIds.get(recordKey);
+        if (!recordId) throw new Error(`BUG: No record ID found for ${recordKey}`);
+
+        await this.deleteRecord(zone, recordId);
+      }
+      for (const target of after.Targets) {
+        await this.createRecord(zone, after, target);
+      }
+    }
+
+    for (const created of changes.Create) {
+      const zone = this.findZoneForName(created.DNSName);
+      if (!zone) throw new Error(`zone not found for ${created.DNSName}`);
+
+      for (const target of created.Targets) {
+        await this.createRecord(zone, created, target);
+      }
+    }
+
+  }
+
+}

--- a/providers/powerdns/mod.ts
+++ b/providers/powerdns/mod.ts
@@ -1,7 +1,6 @@
 import {
   PowerDnsProviderConfig,
   DnsProvider, DnsProviderContext,
-  SplitOutTarget,
   Zone, Endpoint, Changes,
 } from "../../common/mod.ts";
 import { PowerDnsApi } from "./api.ts";
@@ -54,7 +53,6 @@ export class PowerDnsProviderContext implements DnsProviderContext {
             : x.content),
           RecordTTL: recordSet.ttl ?? undefined,
           Priority: recordSet.priority ?? undefined,
-          SplitOutTarget,
         });
       }
     }

--- a/providers/vultr/api.ts
+++ b/providers/vultr/api.ts
@@ -1,4 +1,20 @@
-export class VultrApi {
+export interface VultrApiSurface {
+  listAllZones(): AsyncGenerator<DomainRecord>;
+  listAllRecords(zone: string): AsyncGenerator<DnsRecord>;
+
+  createRecord(zone: string,
+    record: DnsRecordData,
+  ): Promise<DnsRecord>;
+  updateRecord(zone: string,
+    recordId: string,
+    changes: Partial<Omit<DnsRecordData, "type">>,
+  ): Promise<void>;
+  deleteRecord(zone: string,
+    recordId: string,
+  ): Promise<void>;
+}
+
+export class VultrApi implements VultrApiSurface {
 
   #apiKey: string;
   constructor() {
@@ -88,15 +104,17 @@ export class VultrApi {
   }
 }
 
-interface DomainList {
-  domains: Array<{
-    domain: string;
-    date_created: string;
-  }>;
+export interface DomainRecord {
+  domain: string;
+  date_created: string;
+};
+
+export interface DomainList {
+  domains: Array<DomainRecord>;
   meta: ListMeta;
 };
 
-interface DnsRecordData {
+export interface DnsRecordData {
   type: string;
   name: string;
   data: string;
@@ -104,18 +122,18 @@ interface DnsRecordData {
   ttl?: number;
 }
 
-interface DnsRecord extends DnsRecordData {
+export interface DnsRecord extends DnsRecordData {
   id: string;
   priority: number;
   ttl: number;
 }
 
-interface RecordList {
+export interface RecordList {
   records: Array<DnsRecord>;
   meta: ListMeta;
 }
 
-interface ListMeta {
+export interface ListMeta {
   total: number;
   links: {
     next: string, prev: string;

--- a/providers/vultr/mock.ts
+++ b/providers/vultr/mock.ts
@@ -1,0 +1,92 @@
+import { DnsRecord, DnsRecordData, DomainRecord, VultrApiSurface } from "./api.ts";
+
+export class VultrApiMock implements VultrApiSurface {
+
+  #expectDeletions = new Set<string>();
+  #expectCreations = new Set<string>();
+  #creationDatas = new Array<{domain: string, record: DnsRecord}>();
+  #zones = new Map<string, Array<DnsRecord> | undefined>();
+
+  /** Zone that it is an error to interact with */
+  addMockedDeadZone(domain: string) {
+    this.#zones.set(domain, undefined);
+  }
+  addMockedZone(domain: string, records: Array<{data: DnsRecordData, expect: 'retained' | 'deletion' | 'creation'}>) {
+    this.#zones.set(domain, records.flatMap((input, idx) => {
+      const id = `${domain}:${idx}:${input.data.type}`;
+      const fullRecord: DnsRecord = {
+        priority: -1, // TODO: verify actual behavior
+        ttl: 60, // TODO: verify actual behaivor
+        ...input.data,
+        id,
+      };
+      if (input.expect == 'creation') {
+        this.#expectCreations.add([domain, id].join('%'));
+        this.#creationDatas.push({domain, record: fullRecord});
+        return [];
+      }
+      if (input.expect == 'deletion') {
+        this.#expectDeletions.add([domain, id].join('%'));
+      }
+      return [fullRecord];
+    }));
+  }
+  verifyCompletion() {
+    if (this.#expectDeletions.size > 0) throw new Error(
+      `VultrApiMock expected to delete ${Array.from(this.#expectDeletions).join(', ')}`);
+    if (this.#expectCreations.size > 0) throw new Error(
+      `VultrApiMock expected to create ${Array.from(this.#expectCreations).join(', ')}`);
+  }
+
+  async *listAllZones(): AsyncGenerator<DomainRecord> {
+    const date_created = 'mock';
+    for (const domain of this.#zones.keys()) {
+      yield { domain, date_created };
+    }
+  }
+
+  async *listAllRecords(zone: string): AsyncGenerator<DnsRecord> {
+    const records = this.#zones.get(zone);
+    if (!records) throw new Error(`Vultr Mock was asked for unexpected domain ${zone}`);
+    for (const record of records) {
+      yield record;
+    }
+  }
+
+  createRecord(zone: string,
+    record: DnsRecordData,
+  ): Promise<DnsRecord> {
+    const candidate = this.#creationDatas.find(candidate => {
+      if (candidate.domain !== zone) return false;
+      if (candidate.record.name !== record.name) return false;
+      if (candidate.record.type !== record.type) return false;
+      if (candidate.record.data !== record.data) return false;
+      return true;
+    });
+    if (!candidate) throw new Error(
+      `Vultr Mock refusing unexpected creation in ${zone}: ${JSON.stringify(record)}`);
+    if (this.#expectCreations.delete([zone, candidate.record.id].join('%'))) {
+      return Promise.resolve(candidate.record);
+    } else {
+      return Promise.reject(new Error(`Unexpected creation of ${candidate.record.id} - maybe double called`));
+    }
+  }
+
+  updateRecord(zone: string,
+    recordId: string,
+    changes: Partial<Omit<DnsRecordData, "type">>,
+  ): Promise<void> {
+    return Promise.reject(new Error('TODO'));
+  }
+
+  deleteRecord(zone: string,
+    recordId: string,
+  ): Promise<void> {
+    if (this.#expectDeletions.delete([zone, recordId].join('%'))) {
+      return Promise.resolve();
+    } else {
+      return Promise.reject(new Error(`Unexpected deletion of ${recordId} - maybe double called`));
+    }
+  }
+
+}

--- a/providers/vultr/mod.ts
+++ b/providers/vultr/mod.ts
@@ -3,13 +3,13 @@ import {
   DnsProvider, DnsProviderContext,
   Zone, Endpoint, Changes,
 } from "../../common/mod.ts";
-import { VultrApi } from "./api.ts";
+import { VultrApi, VultrApiSurface } from "./api.ts";
 
 export class VultrProvider implements DnsProvider<VultrProviderContext> {
   constructor(
     public config: VultrProviderConfig,
+    private api: VultrApiSurface = new VultrApi(),
   ) {}
-  private api = new VultrApi();
 
 	async NewContext() {
     const zones = new Array<Zone>();
@@ -26,7 +26,7 @@ export class VultrProviderContext implements DnsProviderContext {
   constructor(
     public config: VultrProviderConfig,
     public Zones: Array<Zone>,
-    private api: VultrApi,
+    private api: VultrApiSurface,
   ) {}
 
   private recordIds = new Map<string, string>();
@@ -51,7 +51,7 @@ export class VultrProviderContext implements DnsProviderContext {
         const mapKey = [record.name, record.type, priority].join(':');
         const target = record.type === 'TXT' ? record.data.slice(1, -1) : record.data; // any others?
 
-        const recordKey = this.recordKey(record.name, record.type, priority, target);
+        const recordKey = this.recordKey(dnsName, record.type, priority, target);
         if (this.recordIds.has(recordKey)) throw new Error(`Record key ${recordKey} overlapped`);
         this.recordIds.set(recordKey, record.id);
 

--- a/providers/vultr/mod.ts
+++ b/providers/vultr/mod.ts
@@ -5,13 +5,6 @@ import {
 } from "../../common/mod.ts";
 import { VultrApi } from "./api.ts";
 
-// Store metadata on our Endpoints because the API has its own opaque per-target IDs
-// TODO: do this a different way (Map on the Context)
-type VultrEntry = Endpoint & {
-  vultrIds: string[];
-  vultrZone: string;
-};
-
 export class VultrProvider implements DnsProvider<VultrProviderContext> {
   constructor(
     public config: VultrProviderConfig,
@@ -36,6 +29,11 @@ export class VultrProviderContext implements DnsProviderContext {
     private api: VultrApi,
   ) {}
 
+  private recordIds = new Map<string, string>();
+  private recordKey(name: string, type: string, priority: number | null | undefined, value: string) {
+    return JSON.stringify([name, type, priority ?? null, value]);
+  }
+
   findZoneForName(dnsName: string): Zone | undefined {
     const matches = this.Zones.filter(x => x.DNSName == dnsName || dnsName.endsWith('.'+x.DNSName));
     return matches.sort((a,b) => b.DNSName.length - a.DNSName.length)[0];
@@ -45,7 +43,7 @@ export class VultrProviderContext implements DnsProviderContext {
     const endpoints = new Array<Endpoint>(); // every recordset we find
     for (const zone of this.Zones) {
 
-      const endpMap = new Map<string, VultrEntry>(); // collapse targets with same name/type/priority
+      const endpMap = new Map<string, Endpoint>(); // collapse targets with same name/type/priority
       for await (const record of this.api.listAllRecords(zone.DNSName)) {
 
         const priority = (record.type === 'MX' || record.type === 'SRV') ? record.priority : null;
@@ -53,20 +51,20 @@ export class VultrProviderContext implements DnsProviderContext {
         const mapKey = [record.name, record.type, priority].join(':');
         const target = record.type === 'TXT' ? record.data.slice(1, -1) : record.data; // any others?
 
+        const recordKey = this.recordKey(record.name, record.type, priority, target);
+        if (this.recordIds.has(recordKey)) throw new Error(`Record key ${recordKey} overlapped`);
+        this.recordIds.set(recordKey, record.id);
+
         const existingEndp = endpMap.get(mapKey);
         if (existingEndp) {
           existingEndp.Targets.push(target);
-          existingEndp.vultrIds.push(record.id);
         } else {
-          const endp: VultrEntry = {
+          const endp: Endpoint = {
             DNSName: dnsName,
             RecordType: record.type,
             Targets: [target],
             RecordTTL: record.ttl >= 0 ? record.ttl : undefined,
             Priority: priority ?? undefined,
-            vultrIds: [record.id],
-            vultrZone: zone.DNSName,
-            SplitOutTarget,
           };
           endpoints.push(endp);
           endpMap.set(mapKey, endp);
@@ -79,22 +77,34 @@ export class VultrProviderContext implements DnsProviderContext {
 
   async ApplyChanges(changes: Changes): Promise<void> {
 
-    for (const deleted of changes.Delete as VultrEntry[]) {
-      if (!deleted.vultrIds || deleted.vultrIds.length !== deleted.Targets.length) throw new Error(`BUG`);
-      for (const id of deleted.vultrIds) {
-        await this.api.deleteRecord(deleted.vultrZone, id);
+    for (const deleted of changes.Delete as Endpoint[]) {
+      const zone = this.findZoneForName(deleted.DNSName);
+      if (!zone) throw new Error(`Vultr zone not found for ${deleted.DNSName}`);
+
+      for (const target of deleted.Targets) {
+        const recordKey = this.recordKey(deleted.DNSName, deleted.RecordType, deleted.Priority, target);
+        const recordId = this.recordIds.get(recordKey);
+        if (!recordId) throw new Error(`BUG: No vultr record ID found for ${recordKey}`);
+
+        await this.api.deleteRecord(zone.ZoneID, recordId);
       }
     }
 
-    for (const [before, after] of changes.Update as Array<[VultrEntry, Endpoint]>) {
-      const zone = before.vultrZone;
+    for (const [before, after] of changes.Update as Array<[Endpoint, Endpoint]>) {
+      const zone = this.findZoneForName(before.DNSName);
+      if (!zone) throw new Error(`Vultr zone not found for ${before.DNSName}`);
+
       // TODO: be more efficient with updating-in-place
-      for (const recordId of before.vultrIds) {
-        await this.api.deleteRecord(zone, recordId);
+      for (const target of before.Targets) {
+        const recordKey = this.recordKey(before.DNSName, before.RecordType, before.Priority, target);
+        const recordId = this.recordIds.get(recordKey);
+        if (!recordId) throw new Error(`BUG: No vultr record ID found for ${recordKey}`);
+
+        await this.api.deleteRecord(zone.ZoneID, recordId);
       }
       for (const target of after.Targets) {
-        await this.api.createRecord(zone, {
-          name: after.DNSName == zone ? '' : after.DNSName.slice(0, -zone.length - 1),
+        await this.api.createRecord(zone.ZoneID, {
+          name: after.DNSName == zone.DNSName ? '' : after.DNSName.slice(0, -zone.DNSName.length - 1),
           type: after.RecordType,
           data: after.RecordType === 'TXT' ? `"${target}"` : target,
           ttl: after.RecordTTL ?? undefined,
@@ -105,7 +115,7 @@ export class VultrProviderContext implements DnsProviderContext {
 
     for (const created of changes.Create) {
       const zone = this.findZoneForName(created.DNSName);
-      if (!zone) continue;
+      if (!zone) throw new Error(`Vultr zone not found for ${created.DNSName}`);
 
       for (const target of created.Targets) {
         await this.api.createRecord(zone.ZoneID, {
@@ -120,18 +130,4 @@ export class VultrProviderContext implements DnsProviderContext {
 
   }
 
-}
-
-/// Support splitting records and still keeping vultrIds
-export function SplitOutTarget(this: VultrEntry, predicate: (t: string) => boolean): [VultrEntry, VultrEntry] {
-  const idxs = new Set(this.Targets.flatMap((x, idx) => predicate(x) ? [idx] : []));
-  return [{
-    ...this,
-    Targets: this.Targets.flatMap((x, idx) => idxs.has(idx) ? [x] : []),
-    vultrIds: this.vultrIds.flatMap((x, idx) => idxs.has(idx) ? [x] : []),
-  }, {
-    ...this,
-    Targets: this.Targets.flatMap((x, idx) => idxs.has(idx) ? [] : [x]),
-    vultrIds: this.vultrIds.flatMap((x, idx) => idxs.has(idx) ? [] : [x]),
-  }];
 }

--- a/providers/vultr/mod.ts
+++ b/providers/vultr/mod.ts
@@ -1,8 +1,9 @@
 import {
   VultrProviderConfig,
-  DnsProvider, DnsProviderContext,
-  Zone, Endpoint, Changes,
+  DnsProvider,
+  Zone, Endpoint,
 } from "../../common/mod.ts";
+import { OpaquelyIdentifiedProviderContext, RecordEndpoint } from "../opaquely-identified.ts";
 import { VultrApi, VultrApiSurface } from "./api.ts";
 
 export class VultrProvider implements DnsProvider<VultrProviderContext> {
@@ -20,114 +21,45 @@ export class VultrProvider implements DnsProvider<VultrProviderContext> {
     }
     return new VultrProviderContext(this.config, zones, this.api);
   }
-
 }
-export class VultrProviderContext implements DnsProviderContext {
+
+export class VultrProviderContext extends OpaquelyIdentifiedProviderContext {
   constructor(
     public config: VultrProviderConfig,
-    public Zones: Array<Zone>,
+    Zones: Array<Zone>,
     private api: VultrApiSurface,
-  ) {}
-
-  private recordIds = new Map<string, string>();
-  private recordKey(name: string, type: string, priority: number | null | undefined, value: string) {
-    return JSON.stringify([name, type, priority ?? null, value]);
+  ) {
+    super(Zones);
   }
 
-  findZoneForName(dnsName: string): Zone | undefined {
-    const matches = this.Zones.filter(x => x.DNSName == dnsName || dnsName.endsWith('.'+x.DNSName));
-    return matches.sort((a,b) => b.DNSName.length - a.DNSName.length)[0];
+  async *enumerateRecords(zone: Zone): AsyncGenerator<RecordEndpoint> {
+    for await (const record of this.api.listAllRecords(zone.DNSName)) {
+      const priority = (record.type === 'MX' || record.type === 'SRV') ? record.priority : null;
+      const dnsName = record.name ? `${record.name}.${zone.DNSName}` : zone.DNSName;
+      const target = record.type === 'TXT' ? record.data.slice(1, -1) : record.data; // any others?
+
+      yield {
+        RecordID: record.id,
+        DNSName: dnsName,
+        RecordType: record.type,
+        Targets: [target],
+        RecordTTL: record.ttl >= 0 ? record.ttl : undefined,
+        Priority: priority ?? undefined,
+      };
+    }
   }
 
-  async Records(): Promise<Endpoint[]> {
-    const endpoints = new Array<Endpoint>(); // every recordset we find
-    for (const zone of this.Zones) {
-
-      const endpMap = new Map<string, Endpoint>(); // collapse targets with same name/type/priority
-      for await (const record of this.api.listAllRecords(zone.DNSName)) {
-
-        const priority = (record.type === 'MX' || record.type === 'SRV') ? record.priority : null;
-        const dnsName = record.name ? `${record.name}.${zone.DNSName}` : zone.DNSName;
-        const mapKey = [record.name, record.type, priority].join(':');
-        const target = record.type === 'TXT' ? record.data.slice(1, -1) : record.data; // any others?
-
-        const recordKey = this.recordKey(dnsName, record.type, priority, target);
-        if (this.recordIds.has(recordKey)) throw new Error(`Record key ${recordKey} overlapped`);
-        this.recordIds.set(recordKey, record.id);
-
-        const existingEndp = endpMap.get(mapKey);
-        if (existingEndp) {
-          existingEndp.Targets.push(target);
-        } else {
-          const endp: Endpoint = {
-            DNSName: dnsName,
-            RecordType: record.type,
-            Targets: [target],
-            RecordTTL: record.ttl >= 0 ? record.ttl : undefined,
-            Priority: priority ?? undefined,
-          };
-          endpoints.push(endp);
-          endpMap.set(mapKey, endp);
-        }
-
-      }
-    }
-    return endpoints;
+  async createRecord(zone: Zone, endpoint: Endpoint, value: string) {
+    await this.api.createRecord(zone.ZoneID, {
+      name: endpoint.DNSName == zone.DNSName ? '' : endpoint.DNSName.slice(0, -zone.DNSName.length - 1),
+      type: endpoint.RecordType,
+      data: endpoint.RecordType === 'TXT' ? `"${value}"` : value,
+      ttl: endpoint.RecordTTL ?? undefined,
+      priority: endpoint.Priority ?? undefined,
+    });
   }
 
-  async ApplyChanges(changes: Changes): Promise<void> {
-
-    for (const deleted of changes.Delete as Endpoint[]) {
-      const zone = this.findZoneForName(deleted.DNSName);
-      if (!zone) throw new Error(`Vultr zone not found for ${deleted.DNSName}`);
-
-      for (const target of deleted.Targets) {
-        const recordKey = this.recordKey(deleted.DNSName, deleted.RecordType, deleted.Priority, target);
-        const recordId = this.recordIds.get(recordKey);
-        if (!recordId) throw new Error(`BUG: No vultr record ID found for ${recordKey}`);
-
-        await this.api.deleteRecord(zone.ZoneID, recordId);
-      }
-    }
-
-    for (const [before, after] of changes.Update as Array<[Endpoint, Endpoint]>) {
-      const zone = this.findZoneForName(before.DNSName);
-      if (!zone) throw new Error(`Vultr zone not found for ${before.DNSName}`);
-
-      // TODO: be more efficient with updating-in-place
-      for (const target of before.Targets) {
-        const recordKey = this.recordKey(before.DNSName, before.RecordType, before.Priority, target);
-        const recordId = this.recordIds.get(recordKey);
-        if (!recordId) throw new Error(`BUG: No vultr record ID found for ${recordKey}`);
-
-        await this.api.deleteRecord(zone.ZoneID, recordId);
-      }
-      for (const target of after.Targets) {
-        await this.api.createRecord(zone.ZoneID, {
-          name: after.DNSName == zone.DNSName ? '' : after.DNSName.slice(0, -zone.DNSName.length - 1),
-          type: after.RecordType,
-          data: after.RecordType === 'TXT' ? `"${target}"` : target,
-          ttl: after.RecordTTL ?? undefined,
-          priority: after.Priority ?? undefined,
-        });
-      }
-    }
-
-    for (const created of changes.Create) {
-      const zone = this.findZoneForName(created.DNSName);
-      if (!zone) throw new Error(`Vultr zone not found for ${created.DNSName}`);
-
-      for (const target of created.Targets) {
-        await this.api.createRecord(zone.ZoneID, {
-          name: created.DNSName.slice(0, -zone.DNSName.length - 1),
-          type: created.RecordType,
-          data: created.RecordType === 'TXT' ? `"${target}"` : target,
-          ttl: created.RecordTTL ?? undefined,
-          priority: created.Priority ?? undefined,
-        });
-      }
-    }
-
+  async deleteRecord(zone: Zone, recordId: string) {
+    await this.api.deleteRecord(zone.ZoneID, recordId);
   }
-
 }

--- a/providers/vultr/mod_test.ts
+++ b/providers/vultr/mod_test.ts
@@ -1,0 +1,75 @@
+import { assertEquals } from "https://deno.land/std@0.105.0/testing/asserts.ts";
+import { Changes, Endpoint } from "../../common/contract.ts";
+import { DnsRecord, DnsRecordData, DomainRecord } from "./api.ts";
+import { VultrProvider } from "./mod.ts";
+
+Deno.test('vultr record update', async () => {
+
+  const provider = new VultrProvider({
+    type: 'vultr',
+    domain_filter: ['example.com'],
+  }, {
+    async *listAllZones(): AsyncGenerator<DomainRecord> {
+      yield {
+        domain: 'example.com',
+        date_created: 'mock',
+      };
+      yield {
+        domain: 'another.com',
+        date_created: 'mock',
+      };
+    },
+    async *listAllRecords(): AsyncGenerator<DnsRecord> {
+      yield {
+        id: 'www-A',
+        name: 'www',
+        type: 'A',
+        data: '1.1.1.1',
+        priority: 0,
+        ttl: 60,
+      };
+    },
+    createRecord(zone: string,
+      record: DnsRecordData,
+    ): Promise<DnsRecord> {
+      assertEquals(zone, 'example.com');
+      assertEquals(record.name, 'www');
+      assertEquals(record.data, '2.2.2.2');
+      return Promise.resolve({
+        priority: 0,
+        ttl: 60,
+        ...record,
+        id: 'new-www-A',
+      })
+    },
+    updateRecord(zone: string,
+      recordId: string,
+      changes: Partial<Omit<DnsRecordData, "type">>,
+    ): Promise<void> {
+      return Promise.reject(new Error('TODO'));
+    },
+    deleteRecord(zone: string,
+      recordId: string,
+    ): Promise<void> {
+      assertEquals(zone, 'example.com');
+      assertEquals(recordId, 'www-A');
+      return Promise.resolve();
+    },
+  });
+
+  const ctx = await provider.NewContext();
+
+  const foundEndpoints = await ctx.Records();
+  assertEquals(foundEndpoints.length, 1);
+
+  const newEndpoints: Array<Endpoint> = [{
+    DNSName: 'www.example.com',
+    RecordType: 'A',
+    Targets: ['2.2.2.2'],
+  }];
+
+  const changes = new Changes(newEndpoints, foundEndpoints);
+  changes.Update.push([foundEndpoints[0], newEndpoints[0]]);
+
+  await ctx.ApplyChanges(changes);
+});

--- a/providers/vultr/mod_test.ts
+++ b/providers/vultr/mod_test.ts
@@ -1,66 +1,25 @@
 import { assertEquals } from "https://deno.land/std@0.105.0/testing/asserts.ts";
+
 import { Changes, Endpoint } from "../../common/contract.ts";
-import { DnsRecord, DnsRecordData, DomainRecord } from "./api.ts";
+import { VultrApiMock } from "./mock.ts";
 import { VultrProvider } from "./mod.ts";
 
 Deno.test('vultr record update', async () => {
 
+  const apiMock = new VultrApiMock();
   const provider = new VultrProvider({
     type: 'vultr',
     domain_filter: ['example.com'],
+  }, apiMock);
+
+  apiMock.addMockedDeadZone('another.com');
+  apiMock.addMockedZone('example.com', [{
+    expect: 'deletion',
+    data: { name: 'www', type: 'A', data: '1.1.1.1' },
   }, {
-    async *listAllZones(): AsyncGenerator<DomainRecord> {
-      yield {
-        domain: 'example.com',
-        date_created: 'mock',
-      };
-      yield {
-        domain: 'another.com',
-        date_created: 'mock',
-      };
-    },
-    async *listAllRecords(): AsyncGenerator<DnsRecord> {
-      yield {
-        id: 'www-A',
-        name: 'www',
-        type: 'A',
-        data: '1.1.1.1',
-        priority: 0,
-        ttl: 60,
-      };
-    },
-    createRecord(zone: string,
-      record: DnsRecordData,
-    ): Promise<DnsRecord> {
-      assertEquals(zone, 'example.com');
-      assertEquals(record.name, 'www');
-      assertEquals(record.data, '2.2.2.2');
-      return Promise.resolve({
-        priority: 0,
-        ttl: 60,
-        ...record,
-        id: 'new-www-A',
-      })
-    },
-    updateRecord(zone: string,
-      recordId: string,
-      changes: Partial<Omit<DnsRecordData, "type">>,
-    ): Promise<void> {
-      return Promise.reject(new Error('TODO'));
-    },
-    deleteRecord(zone: string,
-      recordId: string,
-    ): Promise<void> {
-      assertEquals(zone, 'example.com');
-      assertEquals(recordId, 'www-A');
-      return Promise.resolve();
-    },
-  });
-
-  const ctx = await provider.NewContext();
-
-  const foundEndpoints = await ctx.Records();
-  assertEquals(foundEndpoints.length, 1);
+    expect: 'creation',
+    data: { name: 'www', type: 'A', data: '2.2.2.2' },
+  }]);
 
   const newEndpoints: Array<Endpoint> = [{
     DNSName: 'www.example.com',
@@ -68,8 +27,14 @@ Deno.test('vultr record update', async () => {
     Targets: ['2.2.2.2'],
   }];
 
+  const ctx = await provider.NewContext();
+  const foundEndpoints = await ctx.Records();
+  assertEquals(foundEndpoints.length, 1);
+
   const changes = new Changes(newEndpoints, foundEndpoints);
   changes.Update.push([foundEndpoints[0], newEndpoints[0]]);
 
   await ctx.ApplyChanges(changes);
+
+  apiMock.verifyCompletion();
 });

--- a/registries/txt.ts
+++ b/registries/txt.ts
@@ -48,7 +48,7 @@ class TxtRegistryContext implements DnsRegistryContext {
             this.heritageRecords.set(recordset.DNSName, recordset);
             continue;
           } else {
-            const [heritageRec, otherTxts] = recordset.SplitOutTarget(x => x === heritageValue);
+            const [heritageRec, otherTxts] = SplitOutTarget(recordset, x => x === heritageValue);
             this.heritageRecords.set(recordset.DNSName, heritageRec);
             recordset = otherTxts;
           }
@@ -153,7 +153,6 @@ class TxtRegistryContext implements DnsRegistryContext {
         DNSName: txtName,
         RecordType: 'TXT',
         Targets: [Object.entries(labels).map(x => x.join('=')).join(',')],
-        SplitOutTarget,
       } : null;
       // console.log(existingEndpoint, newEndpoint)
 

--- a/sources/acme-crd.ts
+++ b/sources/acme-crd.ts
@@ -1,4 +1,4 @@
-import { AcmeCrdSourceConfig, DnsSource, Endpoint, SplitOutTarget, WatchLister } from "../common/mod.ts";
+import { AcmeCrdSourceConfig, DnsSource, Endpoint, WatchLister } from "../common/mod.ts";
 import { KubernetesClient } from '../deps.ts';
 import { AcmeCertManagerIoV1Api } from "https://deno.land/x/kubernetes_apis@v0.3.1/cert-manager/acme.cert-manager.io@v1/mod.ts";
 
@@ -57,7 +57,6 @@ export class AcmeCrdSource implements DnsSource {
           'external-dns/resource': `acme/${challenge.metadata.namespace}/${challenge.metadata.name}`,
         },
         RecordTTL: this.config.challenge_ttl ?? undefined,
-        SplitOutTarget,
       });
     }
     return endpoints;

--- a/sources/crd.ts
+++ b/sources/crd.ts
@@ -35,14 +35,13 @@ export class CrdSource implements DnsSource {
           },
           RecordTTL: rule.recordTTL ?? undefined,
           ProviderSpecific: (rule.providerSpecific ?? []).map(x => ({Name: x.name ?? '', Value: x.value ?? ''})),
-          SplitOutTarget,
         };
 
         // TODO: also SRV
         if (endpoint.RecordType === 'MX') {
           const allPrios = new Set(endpoint.Targets.map(x => x.split(' ')[0]));
           for (const priority of Array.from(allPrios)) {
-            const subEndpoint = endpoint.SplitOutTarget(x => x.split(' ')[0] === priority)[0];
+            const subEndpoint = SplitOutTarget(endpoint, x => x.split(' ')[0] === priority)[0];
             subEndpoint.Priority = parseInt(priority);
             subEndpoint.Targets = subEndpoint.Targets.map(x => x.split(' ')[1]);
             endpoints.push(subEndpoint);

--- a/sources/ingress.ts
+++ b/sources/ingress.ts
@@ -1,4 +1,4 @@
-import { IngressSourceConfig, DnsSource, Endpoint, SplitOutTarget, SplitByIPVersion, WatchLister } from "../common/mod.ts";
+import { IngressSourceConfig, DnsSource, Endpoint, SplitByIPVersion, WatchLister } from "../common/mod.ts";
 import { KubernetesClient } from '../deps.ts';
 import {
   Ingress as IngressV1, NetworkingV1Api,
@@ -53,7 +53,6 @@ export class IngressSource implements DnsSource {
             Labels: {
               'external-dns/resource': `ingress/${node.metadata.namespace}/${node.metadata.name}`,
             },
-            SplitOutTarget,
           });
         } else if (addresses.length > 0) {
           endpoints.push(...SplitByIPVersion({
@@ -64,7 +63,6 @@ export class IngressSource implements DnsSource {
             Labels: {
               'external-dns/resource': `ingress/${node.metadata.namespace}/${node.metadata.name}`,
             },
-            SplitOutTarget,
           }));
         }
       }

--- a/sources/node.ts
+++ b/sources/node.ts
@@ -1,4 +1,4 @@
-import { NodeSourceConfig, DnsSource, Endpoint, SplitOutTarget, SplitByIPVersion, WatchLister } from "../common/mod.ts";
+import { NodeSourceConfig, DnsSource, Endpoint, SplitByIPVersion, WatchLister } from "../common/mod.ts";
 import { KubernetesClient } from '../deps.ts';
 import { CoreV1Api } from "https://deno.land/x/kubernetes_apis@v0.3.1/builtin/core@v1/mod.ts";
 
@@ -42,7 +42,6 @@ export class NodeSource implements DnsSource {
         Labels: {
           'external-dns/resource': `node/${node.metadata.name}`,
         },
-        SplitOutTarget,
       }));
 
     }


### PR DESCRIPTION
Adds several 'tests' that stress the existing code. A couple unit-ish tests next to individual modules, and also a couple "end-to-end" tests that use a particular config.

Also making the ID-management parts of `vultr` reusable, since Cloudflare and others also want to keep track of opaque provider-provided record IDs.