### PR TITLE
chore(ci): Replace image building with denodir-oci

### DIFF
--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ denodir-oci ]
+    branches: [ main ]
     tags: [ v* ]
     paths-ignore:
       - 'helm-chart/**'
@@ -21,6 +21,7 @@ jobs:
         deno-version:
         # v1.17 and earlier lack Intl.ListFormat type
         - v1.18
+        - v1.19
         - canary
       fail-fast: false # run each branch to completion
 

--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -73,14 +73,15 @@ jobs:
       - name: Determine image name
         id: name
         run: |
-          IMAGE_ID=ghcr.io/${{ github.repository }}
+          IMAGE_ID=ghcr.io/cloudydeno/dns-sync
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           if [[ "${{ github.ref }}" == "refs/tags/"* ]]
-          then VERSION=$(echo $VERSION | sed -e 's/^v//')
-          else VERSION=${{ github.sha }}
+          then VERSION=$( echo $VERSION | sed -e 's/^v//' )
+          else VERSION=$( echo ${{ github.sha }} | cut -c1-7 )
           fi
           echo "Will push to $IMAGE_ID:$VERSION"
-          echo "::set-output name=image::$IMAGE_ID:$VERSION"
+          echo "::set-output name=image::$IMAGE_ID"
+          echo "::set-output name=tag::$VERSION"
 
       - name: Log into GitHub Container Registry
         uses: docker/login-action@v1
@@ -93,9 +94,9 @@ jobs:
 
       - name: Build denodir
         run: doci pipeline build
-      - name: Push denodir image
-        run: doci pipeline push ${{ steps.name.outputs.image }}-denodir
+      # - name: Push denodir image
+      #   run: doci pipeline push ${{ steps.name.outputs.image }}-denodir:${{ steps.name.outputs.tag }}
       - name: Push alpine image
-        run: doci pipeline push ${{ steps.name.outputs.image }}-alpine --eject alpine
+        run: doci pipeline push ${{ steps.name.outputs.image }}-alpine:${{ steps.name.outputs.tag }} --eject alpine
       - name: Push multiarch image
-        run: doci pipeline push ${{ steps.name.outputs.image }}-multiarch --eject multiarch
+        run: doci pipeline push ${{ steps.name.outputs.image }}-multiarch:${{ steps.name.outputs.tag }} --eject multiarch

--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -59,17 +59,26 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
+      - name: Use Deno stable
+        uses: denoland/setup-deno@v1
+      - name: Cache https://
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/deno/deps/https
+          key: deno-https/v1-${{ github.sha }}-doci
+          restore-keys: deno-https/v1-
+      - name: Install denodir-oci utility
+        run: deno install --allow-{read,write}=$HOME,${TMPDIR:-/tmp} --allow-run --allow-net --allow-env --reload=https://raw.githubusercontent.com https://raw.githubusercontent.com/cloudydeno/denodir-oci/main/doci/mod.ts
+
       - name: Determine image name
         id: name
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository }}
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           if [[ "${{ github.ref }}" == "refs/tags/"* ]]
           then VERSION=$(echo $VERSION | sed -e 's/^v//')
           else VERSION=${{ github.sha }}
           fi
-          # [ "$VERSION" == "main" ] && VERSION=latest
           echo "Will push to $IMAGE_ID:$VERSION"
           echo "::set-output name=image::$IMAGE_ID:$VERSION"
 
@@ -82,67 +91,8 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build and push
-        uses: docker/build-push-action@v2.9.0
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          tags: ${{ steps.name.outputs.image }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-  push-multiarch:
-    needs: check
-    runs-on: ubuntu-latest
-    name: 'Push multi-arch image'
-    if: github.event_name == 'push'
-
-    steps:
-
-      - name: Determine image name
-        id: name
-        run: |
-          IMAGE_ID=ghcr.io/${{ github.repository }}
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          if [[ "${{ github.ref }}" == "refs/tags/"* ]]
-          then VERSION=$(echo $VERSION | sed -e 's/^v//')
-          else VERSION=${{ github.sha }}
-          fi
-          TAG=$VERSION-multiarch
-          # [ "$TAG" == "main-multiarch" ] && TAG=multiarch
-          echo "Will push to $IMAGE_ID:$TAG"
-          echo "::set-output name=image::$IMAGE_ID:$TAG"
-
-      - name: Log into GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: x-access-token
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/checkout@v2
-      - name: Prep multiarch Dockerfile
-        run: |
-          sed s@denoland/deno:alpine-@lukechannings/deno:v@ Dockerfile > Dockerfile.multiarch
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build and push
-        uses: docker/build-push-action@v2.9.0
-        with:
-          context: .
-          file: Dockerfile.multiarch
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.name.outputs.image }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - run: doci cache src/deps.ts
+      - run: doci build src/main.ts --unstable --permissions-flags "--allow-hrtime --allow-net --allow-read --allow-env"
+      - run: doci push ${{ steps.name.outputs.image }}-denodir
+      - run: doci eject --push ${{ steps.name.outputs.image }}-alpine --base denoland/deno:alpine-1.18.2
+      - run: doci eject --push ${{ steps.name.outputs.image }}-multiarch --base lukechannings/deno:v1.18.2

--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -91,11 +91,11 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: [DOCI] Build
+      - name: Build denodir
         run: doci pipeline build
-      - name: [DOCI] Push denodir image
+      - name: Push denodir image
         run: doci pipeline push ${{ steps.name.outputs.image }}-denodir
-      - name: [DOCI] Push alpine image
+      - name: Push alpine image
         run: doci pipeline push ${{ steps.name.outputs.image }}-alpine --eject alpine
-      - name: [DOCI] Push multiarch image
+      - name: Push multiarch image
         run: doci pipeline push ${{ steps.name.outputs.image }}-multiarch --eject multiarch

--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ denodir-oci ]
     tags: [ v* ]
     paths-ignore:
       - 'helm-chart/**'

--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -91,8 +91,11 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - run: doci cache src/deps.ts
-      - run: doci build src/main.ts --unstable --permissions-flags "--allow-hrtime --allow-net --allow-read --allow-env"
-      - run: doci push ${{ steps.name.outputs.image }}-denodir
-      - run: doci eject --push ${{ steps.name.outputs.image }}-alpine --base denoland/deno:alpine-1.18.2
-      - run: doci eject --push ${{ steps.name.outputs.image }}-multiarch --base lukechannings/deno:v1.18.2
+      - name: [DOCI] Build
+        run: doci pipeline build
+      - name: [DOCI] Push denodir image
+        run: doci pipeline push ${{ steps.name.outputs.image }}-denodir
+      - name: [DOCI] Push alpine image
+        run: doci pipeline push ${{ steps.name.outputs.image }}-alpine --eject alpine
+      - name: [DOCI] Push multiarch image
+        run: doci pipeline push ${{ steps.name.outputs.image }}-multiarch --eject multiarch

--- a/doci.yaml
+++ b/doci.yaml
@@ -6,6 +6,7 @@ dependencyLayers:
 
 runtimeFlags:
 - --unstable
+- --no-check
 - --allow-hrtime
 - --allow-net
 - --allow-read

--- a/doci.yaml
+++ b/doci.yaml
@@ -1,0 +1,18 @@
+entrypoint:
+  specifier: src/main.ts
+
+dependencyLayers:
+- specifier: src/deps.ts
+
+runtimeFlags:
+- --unstable
+- --allow-hrtime
+- --allow-net
+- --allow-read
+- --allow-env
+
+ejections:
+  alpine:
+    base: denoland/deno:alpine-1.18.2
+  multiarch:
+    base: lukechannings/deno:v1.18.2


### PR DESCRIPTION
[denodir-oci](https://github.com/cloudydeno/denodir-oci) is a different project of mine that builds runnable Docker images without actually using Docker, and it is able to emit multiarch images natively.