### PR TITLE
Refresh CI for Deno 2

### DIFF
--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ ci-fix ]
     tags: [ v* ]
     paths-ignore:
       - 'helm-chart/**'
@@ -70,7 +70,7 @@ jobs:
           key: deno-https/v1-${{ github.sha }}-doci
           restore-keys: deno-https/v1-
       - name: Install denodir-oci utility
-        run: deno install --allow-{read,write}=$HOME,${TMPDIR:-/tmp} --allow-run --allow-net --allow-env --reload=https://raw.githubusercontent.com https://raw.githubusercontent.com/cloudydeno/denodir-oci/main/doci/mod.ts
+        run: deno install --global --allow-read --allow-write=$HOME,${TMPDIR:-/tmp} --allow-run --allow-net --allow-env --reload=https://raw.githubusercontent.com https://raw.githubusercontent.com/cloudydeno/denodir-oci/main/doci/mod.ts
 
       - name: Determine image name
         id: name
@@ -100,5 +100,3 @@ jobs:
       #   run: doci pipeline push --tag ${{ steps.name.outputs.tag }} --target denodir
       - name: Push alpine image
         run: doci pipeline push --tag ${{ steps.name.outputs.tag }} --target alpine
-      - name: Push multiarch image
-        run: doci pipeline push --tag ${{ steps.name.outputs.tag }} --target multiarch

--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -38,7 +38,9 @@ jobs:
     - name: Cache https://
       uses: actions/cache@v4
       with:
-        path: ~/.cache/deno/remote/https ~/.cache/deno/gen/https
+        path: |
+          ~/.cache/deno/remote/https
+          ~/.cache/deno/gen/https
         key: deno-https/v2-${{ github.sha }}
         restore-keys: deno-https/v2-
 
@@ -66,7 +68,9 @@ jobs:
       - name: Cache https://
         uses: actions/cache@v4
         with:
-          path: ~/.cache/deno/remote/https ~/.cache/deno/gen/https
+          path: |
+            ~/.cache/deno/remote/https
+            ~/.cache/deno/gen/https
           key: deno-https/v2-${{ github.sha }}-doci
           restore-keys: deno-https/v2-
       - name: Install denodir-oci utility

--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ ci-fix ]
+    branches: [ main ]
     tags: [ v* ]
     paths-ignore:
       - 'helm-chart/**'

--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Cache https://
       uses: actions/cache@v4
       with:
-        path: ~/.cache/deno/deps/https
+        path: ~/.cache/deno/remote/https
         key: deno-https/v2-${{ github.sha }}
         restore-keys: deno-https/v2-
 
@@ -66,9 +66,9 @@ jobs:
       - name: Cache https://
         uses: actions/cache@v4
         with:
-          path: ~/.cache/deno/deps/https
-          key: deno-https/v1-${{ github.sha }}-doci
-          restore-keys: deno-https/v1-
+          path: ~/.cache/deno/remote/https
+          key: deno-https/v2-${{ github.sha }}-doci
+          restore-keys: deno-https/v2-
       - name: Install denodir-oci utility
         run: deno install --global --allow-read --allow-write=$HOME,${TMPDIR:-/tmp} --allow-run --allow-net --allow-env --reload=https://raw.githubusercontent.com https://raw.githubusercontent.com/cloudydeno/denodir-oci/main/doci/mod.ts
 

--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Cache https://
       uses: actions/cache@v4
       with:
-        path: ~/.cache/deno/remote/https
+        path: ~/.cache/deno/remote/https ~/.cache/deno/gen/https
         key: deno-https/v2-${{ github.sha }}
         restore-keys: deno-https/v2-
 
@@ -66,7 +66,7 @@ jobs:
       - name: Cache https://
         uses: actions/cache@v4
         with:
-          path: ~/.cache/deno/remote/https
+          path: ~/.cache/deno/remote/https ~/.cache/deno/gen/https
           key: deno-https/v2-${{ github.sha }}-doci
           restore-keys: deno-https/v2-
       - name: Install denodir-oci utility

--- a/doci.yaml
+++ b/doci.yaml
@@ -18,6 +18,3 @@ targets:
   alpine:
     ref: ghcr.io/cloudydeno/dns-sync-alpine
     baseRef: denoland/deno:alpine-$DenoVersion
-  multiarch:
-    ref: ghcr.io/cloudydeno/dns-sync-multiarch
-    baseRef: lukechannings/deno:v$DenoVersion


### PR DESCRIPTION
Gets updated images pushed out.

Removing multiarch image variant as the alpine image is nowadays multiarch.